### PR TITLE
Fix Tenant Creation

### DIFF
--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -94,14 +94,15 @@ module Apartment
       #   @param {String?} tenant to connect to
       #
       def switch(tenant = nil, base = false)
+        perform_switch = -> (tenant) { base ? base_switch!(tenant) : switch!(tenant) }
         if block_given?
           begin
             previous_tenant = current
-            base ? base_switch!(tenant) : switch!(tenant)
+            perform_switch.(tenant)
             yield
 
           ensure
-            switch!(previous_tenant) rescue reset
+            perform_switch.(previous_tenant) rescue reset
           end
         else
           Apartment::Deprecation.warn("[Deprecation Warning] `switch` now requires a block reset to the default tenant after the block. Please use `switch!` instead if you don't want this")

--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -20,13 +20,15 @@ module Apartment
       def create(tenant)
         create_tenant(tenant)
 
-        switch(tenant) do
-          import_database_schema
+        switch(tenant, true) do
+          switch(tenant) do
+            import_database_schema
 
-          # Seed data if appropriate
-          seed_data if Apartment.seed_after_create
+            # Seed data if appropriate
+            seed_data if Apartment.seed_after_create
 
-          yield if block_given?
+            yield if block_given?
+          end
         end
       end
 

--- a/lib/tasks/apartment.rake
+++ b/lib/tasks/apartment.rake
@@ -3,7 +3,7 @@ require 'apartment/migrator'
 apartment_namespace = namespace :apartment do
 
   desc "Create all tenants"
-  task create: 'db:migrate' do
+  task create: :environment do
     tenants.each do |tenant|
       begin
         puts("Creating #{tenant} tenant")


### PR DESCRIPTION
This was a bit of a brute to track down, but I've figured out why the base Apartment rake tasks don't work like they should out of the box. Check out the commit messages for more specifics, but the TL;DR is that we have to perform a "base" switch and a regular "non-base" switch of the tenant prior to loading the schema.