### PR TITLE
Fix broken Migrator tasks

### DIFF
--- a/lib/apartment/migrator.rb
+++ b/lib/apartment/migrator.rb
@@ -8,10 +8,12 @@ module Apartment
     # Migrate to latest
     def migrate(database)
       Tenant.switch(database, true) do
-        version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil
+        Tenant.switch(database) do
+          version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil
 
-        ActiveRecord::Migrator.migrate(ActiveRecord::Migrator.migrations_paths, version) do |migration|
-          ENV["SCOPE"].blank? || (ENV["SCOPE"] == migration.scope)
+          ActiveRecord::Migrator.migrate(ActiveRecord::Migrator.migrations_paths, version) do |migration|
+            ENV["SCOPE"].blank? || (ENV["SCOPE"] == migration.scope)
+          end
         end
       end
     end
@@ -19,14 +21,18 @@ module Apartment
     # Migrate up/down to a specific version
     def run(direction, database, version)
       Tenant.switch(database, true) do
-        ActiveRecord::Migrator.run(direction, ActiveRecord::Migrator.migrations_paths, version)
+        Tenant.switch(database) do
+          ActiveRecord::Migrator.run(direction, ActiveRecord::Migrator.migrations_paths, version)
+        end
       end
     end
 
     # rollback latest migration `step` number of times
     def rollback(database, step = 1)
       Tenant.switch(database, true) do
-        ActiveRecord::Migrator.rollback(ActiveRecord::Migrator.migrations_paths, step)
+        Tenant.switch(database) do
+          ActiveRecord::Migrator.rollback(ActiveRecord::Migrator.migrations_paths, step)
+        end
       end
     end
   end


### PR DESCRIPTION
This is the same issue fixed on the #create method in a previous commit:

ad2428050b976d271e3aa2bf6911ce0525668a33

In short, we need to switch the tenant on both the base
ActiveRecord::Base connection and on all other model connections. I
believe the double switch is required because of the ConnectionPool
class that we added.