### PR TITLE
Fix deadlocks in migration transactions

### DIFF
--- a/lib/apartment/connection_pool.rb
+++ b/lib/apartment/connection_pool.rb
@@ -18,7 +18,7 @@ module Apartment
 
     def class_for_model(klass)
       if use_default_pool?(klass)
-        klass
+        Apartment.connection_class
       else
         database = Apartment::Tenant.current
         class_for_database(database)
@@ -57,9 +57,16 @@ module Apartment
     end
 
     def use_default_pool?(klass)
-      klass == ActiveRecord::Base ||
+      class_always_excluded?(klass) ||
         Apartment.use_schemas ||
         Apartment.excluded_models.include?(klass.name)
+    end
+
+    def class_always_excluded?(klass)
+      [
+        ActiveRecord::Base,
+        ActiveRecord::SchemaMigration,
+      ].include?(klass)
     end
   end
 end


### PR DESCRIPTION
Migrations were failing after all of the steps completed successfully
and the `schema_migrations` table was being updated. Intuitively, this
wouldn't be a problem as no migration will ever directly touch this
table so there should never be any resource contention. However, the
model runs a check to see if the `schema_migrations` table has been
created yet. This does a query for the list of tables, and if the
migration that just ran had created or removed a table we now have a
deadlock.

The whole source of this problem though is that these two queries--the
migration query and the query for the list of tables--are happening in
two separate connections. If they were in the same connection the server
would not consider the resource contended. So what we needed was to make
all of this run in the same connection. This required updating two
things.

First, the `ActiveRecord::SchemaMigration` model needs to just use the
base connection rather than trying to use the currently active
connection for the tenant. The reason for this is that Rails runs all
migration tasks on the base connection and if we want them to run on the
same connection we cannot run it on the tenant connection.

Second, the `class_for_model` method needs to return the
`Apartment.connection_class` rather than whatever the connection is for
the current class. This one took me awhile to track down, and I ended up
discovering it by printing out object ids of connection pools and
discovering that the pool for `ActiveRecord::Base` and the pool for
`ActiveRecord::SchemaMigration` were in fact different. With this change
we will be ensured that they will use the same pool. I believe this was
the intended behavior anyway.

I can confirm that after these changes the migration will in fact run in
a transaction as expected without deadlock.